### PR TITLE
check for hm env type

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Maintained by [Chris Reynolds](https://github.com/jazzsequence).
 
 ### 1.0.1
 * Flipped the logic of the admin setting from checking to _disable_ basic authentication to checking to _enable_ basic authentication, and defaulting to environment-based settings.
+* Added a `is_development_environment` function which includes an added check for `HM_ENV_TYPE` as well as arbitrary definitions that could be added by a filter.
 
 ### 1.0
 * Initial release

--- a/inc/basic-auth.php
+++ b/inc/basic-auth.php
@@ -15,7 +15,7 @@ namespace HM\BasicAuth;
  * Basic auth username and password should be set wherever constants for the site are defined.
  */
 function require_auth() {
-	$override_basic_auth = get_option( 'hm-basic-auth' );
+	$basic_auth = get_option( 'hm-basic-auth' );
 
 	if (
 		// Bail if basic auth has been disabled...

--- a/inc/basic-auth.php
+++ b/inc/basic-auth.php
@@ -20,8 +20,8 @@ function require_auth() {
 	if (
 		// Bail if basic auth has been disabled...
 		( ! $basic_auth || 'off' === $basic_auth ) ||
-		// ...or if HM_DEV isn't defined or explicitly false.
-		( ! defined( 'HM_DEV' ) || defined( 'HM_DEV' ) && ! HM_DEV )
+		// ...or if the development environment isn't defined or explicitly false.
+		( ! is_development_environment() )
 	) {
 		return;
 	}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -63,13 +63,8 @@ function register_settings() {
  * The basic auth override setting.
  */
 function basic_auth_setting_callback() {
-	/*
-	 * If hm-basic-auth is false or empty, it means we haven't stored a value
-	 * yet.
-	 * Use the is_development_environment value here to default to the default,
-	 * environment-controlled setup.
-	 */
-	$checked = get_option( 'hm-basic-auth' ) ?: is_development_environment();
+	$hm_dev  = is_development_environment() ? 'on' : 'off';
+	$checked = get_option( 'hm-basic-auth' ) ?: $hm_dev;
 	?>
 	<input type="checkbox" name="hm-basic-auth" value="on" <?php checked( $checked, 'on' ); ?> />
 	<span class="description">

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -45,7 +45,7 @@ function is_development_environment() : bool {
  * We don't want basic auth in production.
  */
 function register_settings() {
-	if ( defined( 'HM_DEV' ) && HM_DEV ) {
+	if ( is_development_environment() ) {
 		register_setting( 'general', 'hm-basic-auth', [ 'sanitize_callback' => __NAMESPACE__ . '\\basic_auth_sanitization_callback' ] );
 
 		add_settings_field(
@@ -63,8 +63,7 @@ function register_settings() {
  * The basic auth override setting.
  */
 function basic_auth_setting_callback() {
-	$hm_dev  = defined( 'HM_DEV' ) ? absint( HM_DEV ) : false;
-	$checked = get_option( 'hm-basic-auth' ) ?: $hm_dev;
+	$checked = get_option( 'hm-basic-auth' ) ?: is_development_environment();
 	?>
 	<input type="checkbox" name="hm-basic-auth" value="on" <?php checked( $checked, 'on' ); ?> />
 	<span class="description">

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -17,6 +17,30 @@ function bootstrap() {
 }
 
 /**
+ * Checks if we're in a development environment.
+ *
+ * @return bool Returns true if we are in a dev or staging environment, false if not.
+ */
+function is_development_environment() : bool {
+	$hm_dev    = defined( 'HM_DEV' ) && HM_DEV;
+	$altis_dev = defined( 'HM_ENV_TYPE' ) && in_array( HM_ENV_TYPE, [ 'development', 'staging' ] );
+
+	/**
+	 * Allow our environments to be filtered outside of the plugin.
+	 *
+	 * @param bool
+	 */
+	$other_dev = apply_filters( 'hmauth_filter_dev_env', false );
+
+	// If any of the environment checks are true, we're in a dev environment.
+	if ( $hm_dev || $altis_dev || $other_dev ) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
  * Register the basic auth setting and the new settings field, but only if we're in a dev environment.
  * We don't want basic auth in production.
  */

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -63,6 +63,12 @@ function register_settings() {
  * The basic auth override setting.
  */
 function basic_auth_setting_callback() {
+	/*
+	 * If hm-basic-auth is false or empty, it means we haven't stored a value
+	 * yet.
+	 * Use the is_development_environment value here to default to the default,
+	 * environment-controlled setup.
+	 */
 	$checked = get_option( 'hm-basic-auth' ) ?: is_development_environment();
 	?>
 	<input type="checkbox" name="hm-basic-auth" value="on" <?php checked( $checked, 'on' ); ?> />


### PR DESCRIPTION
* adds a new `is_development_environment` function which includes the `HM_DEV` check, a new `HM_ENV_TYPE` check, as well as any arbitrary value added via a new filter to determine whether we are in a development environment.

fixes #2