### PR TITLE
option check

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ You should also add these lines to your `wp-config-local.sample.php`.
 
 ## Changelog
 
+### 1.1.1
+* Fixed a bug where the environment settings were getting short-circuited if the option was unset.
+
 ### 1.1
 * Flipped the logic of the admin setting from checking to _disable_ basic authentication to checking to _enable_ basic authentication, and defaulting to environment-based settings.
 * Added a `is_development_environment` function which includes an added check for `HM_ENV_TYPE` as well as arbitrary definitions that could be added by a filter.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -109,12 +109,8 @@ function basic_auth_sanitization_callback( $value ) : string {
 function require_auth() {
 	$basic_auth = get_option( 'hm-basic-auth' );
 
-	if (
-		// Bail if basic auth has been disabled...
-		( ! $basic_auth || 'off' === $basic_auth ) ||
-		// ...or if the development environment isn't defined or explicitly false.
-		( ! is_development_environment() )
-	) {
+	// Bail if basic auth has been disabled or if the development environment isn't defined or explicitly false.
+	if ( 'off' === $basic_auth || ! is_development_environment() ) {
 		return;
 	}
 

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Description: Basic PHP authentication for HM Dev and Staging environments.
  * Author: Human Made Limited
  * Author URI: https://humanmade.com
- * Version: 1.1
+ * Version: 1.1.1
  *
  * @package HM\BasicAuth
  */


### PR DESCRIPTION
Option was short-circuiting the environment check if not set. Removed the `! $basic_auth` condition when checking the option value.