### PR TITLE
Fix altis healthcheck bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ You should also add these lines to your `wp-config-local.sample.php`.
 
 ## Changelog
 
+### 1.1.4
+* Added an exclusion for `WP_INSTALLING` which was resulting in a bug that was failing Altis healthchecks.
+
 ### 1.1.3
 * Added an action hook to the `is_development_environment` check, to allow actions to be hooked in before checking the environment.
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -46,13 +46,15 @@ function is_development_environment() : bool {
 	$other_dev = apply_filters( 'hmauth_filter_dev_env', false );
 
 	// Don't require auth for AJAX requests.
-	$exclude_ajax   = ! defined( 'DOING_AJAX' ) || false === DOING_AJAX;
+	$exclude_ajax       = ! defined( 'DOING_AJAX' ) || false === DOING_AJAX;
 	// Don't require auth if we're in wp-cli.
-	$exclude_wp_cli = ! defined( 'WP_CLI' ) || false === WP_CLI;
+	$exclude_wp_cli     = ! defined( 'WP_CLI' ) || false === WP_CLI;
 	// Don't require auth when running cron jobs.
-	$exclude_cron   = ! defined( 'DOING_CRON' ) || false === DOING_CRON;
+	$exclude_cron       = ! defined( 'DOING_CRON' ) || false === DOING_CRON;
+	// Don't require auth when installing or doing Altis health checks.
+	$exclude_installing = ! defined( 'WP_INSTALLING' ) || false === WP_INSTALLING;
 
-	$exclude = $exclude_ajax && $exclude_wp_cli && $exclude_cron;
+	$exclude = $exclude_ajax && $exclude_wp_cli && $exclude_cron && $exclude_installing;
 
 	if (
 		// WordPress exclusions.

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Description: Basic PHP authentication for HM Dev and Staging environments.
  * Author: Human Made Limited
  * Author URI: https://humanmade.com
- * Version: 1.1.3
+ * Version: 1.1.4
  *
  * @package HM\BasicAuth
  */


### PR DESCRIPTION
Adds an exclusion for `WP_INSTALLING` which should resolve Altis healthcheck issue.