### PR TITLE
Only show on production if user is super admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ You should also add these lines to your `wp-config-local.sample.php`.
 ### 1.1.6
 * Fix unit tests
 * Update composer test script to use composer-installed version of phpunit
+* Bail early if credentials aren't defined
+* Allow production environments to possibly enable auth
 
 ### 1.1.5
 * Fixed bug where the `hmauth_filter_dev_env` is ignored if credentials are already set.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -60,7 +60,7 @@ function is_development_environment() : bool {
 		// WordPress exclusions.
 		$exclude &&
 		// If any of the environment checks are true, we're in a dev environment.
-		( $hm_dev || $altis_dev || $other_dev || $creds_defined )
+		( $hm_dev || $altis_dev || $other_dev )
 	) {
 		return true;
 	}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -60,7 +60,7 @@ function is_development_environment() : bool {
 		// WordPress exclusions.
 		$exclude &&
 		// If any of the environment checks are true, we're in a dev environment.
-		( $hm_dev || $altis_dev || ( $other_dev && is_super_admin() ) || $creds_defined )
+		( $hm_dev || $altis_dev || $other_dev || $creds_defined )
 	) {
 		return true;
 	}
@@ -74,12 +74,8 @@ function is_development_environment() : bool {
  * @return bool
  */
 function enable_auth(): bool {
-	$other_dev = apply_filters( 'hmauth_filter_dev_env', false );
-
 	if (
-		defined( 'HM_DEV' ) && HM_DEV ||
-		defined( 'HM_ENV_TYPE' ) && HM_ENV_TYPE !== 'production' && ! is_super_admin() && ! $other_dev
-	) {
+		! is_super_admin() && defined( 'HM_ENV_TYPE' ) && HM_ENV_TYPE === 'production' ) {
 		return false;
 	}
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -79,9 +79,7 @@ function is_development_environment() : bool {
  * @return bool
  */
 function enable_auth(): bool {
-	if (
-		! is_super_admin() && defined( 'HM_ENV_TYPE' ) && HM_ENV_TYPE === 'production' 
-	) {
+	if ( ! is_super_admin() && defined( 'HM_ENV_TYPE' ) && HM_ENV_TYPE === 'production' ) {
 		return false;
 	}
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -36,7 +36,6 @@ function is_development_environment() : bool {
 
 	$hm_dev        = defined( 'HM_DEV' ) && HM_DEV;
 	$altis_dev     = defined( 'HM_ENV_TYPE' ) && in_array( HM_ENV_TYPE, [ 'development', 'staging' ] );
-	$creds_defined = defined( 'HM_BASIC_AUTH_USER' ) && defined( 'HM_BASIC_AUTH_PW' );
 
 	/**
 	 * Allow our environments to be filtered outside of the plugin.
@@ -44,6 +43,12 @@ function is_development_environment() : bool {
 	 * @param bool
 	 */
 	$other_dev = apply_filters( 'hmauth_filter_dev_env', false );
+
+	// Bail early if the credentials are missing.
+	$creds_defined = defined( 'HM_BASIC_AUTH_USER' ) && defined( 'HM_BASIC_AUTH_PW' );
+	if ( ! $creds_defined ) {
+		return false;
+	}
 
 	// Don't require auth for AJAX requests.
 	$exclude_ajax       = ! defined( 'DOING_AJAX' ) || false === DOING_AJAX;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -44,8 +44,9 @@ function is_development_environment() : bool {
 	 */
 	$other_dev = apply_filters( 'hmauth_filter_dev_env', false );
 
-	// Bail early if the credentials are missing.
 	$creds_defined = defined( 'HM_BASIC_AUTH_USER' ) && defined( 'HM_BASIC_AUTH_PW' );
+
+	// Bail early if the credentials are missing.
 	if ( ! $creds_defined ) {
 		return false;
 	}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -80,7 +80,8 @@ function is_development_environment() : bool {
  */
 function enable_auth(): bool {
 	if (
-		! is_super_admin() && defined( 'HM_ENV_TYPE' ) && HM_ENV_TYPE === 'production' ) {
+		! is_super_admin() && defined( 'HM_ENV_TYPE' ) && HM_ENV_TYPE === 'production' 
+	) {
 		return false;
 	}
 

--- a/tests/class-test-main.php
+++ b/tests/class-test-main.php
@@ -15,8 +15,6 @@ class Test_Main extends \WP_UnitTestCase {
 	 * Check a variety of conditions that would effect whether is_development_environment retuns true or false.
 	 */
 	public function test_is_development_environment() {
-		$this->markTestSkipped( 'Re-add test after $creds_defined is removed check from namespace.php' );
-
 		// Start by assuming we're not in a dev environment.
 		$this->assertFalse(
 			is_development_environment()


### PR DESCRIPTION
@jazzsequence Based on our earlier discussions, here is some code that _should_ only enable it on production. I have looked at the code a lot this morning as I had a weird bug locally that was unrelated to I might have missed something.

However the idea is that:
If the current environment is production and the user isn't a super_admin then it won't display the field.