### PR TITLE
Prevent basic auth from blocking robots.txt

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -52,11 +52,11 @@ function is_development_environment() : bool {
 	}
 
 	// Don't require auth for AJAX requests.
-	$exclude_ajax       = ! defined( 'DOING_AJAX' ) || false === DOING_AJAX;
+	$exclude_ajax = ! defined( 'DOING_AJAX' ) || false === DOING_AJAX;
 	// Don't require auth if we're in wp-cli.
-	$exclude_wp_cli     = ! defined( 'WP_CLI' ) || false === WP_CLI;
+	$exclude_wp_cli = ! defined( 'WP_CLI' ) || false === WP_CLI;
 	// Don't require auth when running cron jobs.
-	$exclude_cron       = ! defined( 'DOING_CRON' ) || false === DOING_CRON;
+	$exclude_cron = ! defined( 'DOING_CRON' ) || false === DOING_CRON;
 	// Don't require auth when installing or doing Altis health checks.
 	$exclude_installing = ! defined( 'WP_INSTALLING' ) || false === WP_INSTALLING;
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -35,7 +35,7 @@ function is_development_environment() : bool {
 	do_action( 'hmauth_action_before_dev_env_check' );
 
 	$hm_dev        = defined( 'HM_DEV' ) && HM_DEV;
-	$altis_dev     = defined( 'HM_ENV_TYPE' ) && in_array( HM_ENV_TYPE, [ 'development', 'staging' ] );
+	$altis_dev     = defined( 'HM_ENV_TYPE' ) && in_array( HM_ENV_TYPE, [ 'development', 'staging' ], true );
 
 	/**
 	 * Allow our environments to be filtered outside of the plugin.
@@ -52,13 +52,13 @@ function is_development_environment() : bool {
 	}
 
 	// Don't require auth for AJAX requests.
-	$exclude_ajax       = ! defined( 'DOING_AJAX' ) || false === DOING_AJAX;
+	$exclude_ajax		= ! defined( 'DOING_AJAX' ) || false === DOING_AJAX;
 	// Don't require auth if we're in wp-cli.
-	$exclude_wp_cli     = ! defined( 'WP_CLI' ) || false === WP_CLI;
+	$exclude_wp_cli		= ! defined( 'WP_CLI' ) || false === WP_CLI;
 	// Don't require auth when running cron jobs.
-	$exclude_cron       = ! defined( 'DOING_CRON' ) || false === DOING_CRON;
+	$exclude_cron		= ! defined( 'DOING_CRON' ) || false === DOING_CRON;
 	// Don't require auth when installing or doing Altis health checks.
-	$exclude_installing = ! defined( 'WP_INSTALLING' ) || false === WP_INSTALLING;
+	$exclude_installing	= ! defined( 'WP_INSTALLING' ) || false === WP_INSTALLING;
 
 	$exclude = $exclude_ajax && $exclude_wp_cli && $exclude_cron && $exclude_installing;
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -154,6 +154,12 @@ function require_auth() {
 		'/robots.txt',
 	];
 
+	/**
+	 * Filters which pages are allowed through basic auth.
+	 *
+	 */
+	$allowed = apply_filters( 'hm-basic-auth.allowed_pages', $allowed );
+
 	if ( $_SERVER['REQUEST_URI'] && in_array( $_SERVER['REQUEST_URI'], $allowed, true ) ) {
 		add_filter( 'robots_txt', __NAMESPACE__ . '\\create_robots_file' );
 		return;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -150,6 +150,15 @@ function require_auth() {
 		return;
 	}
 
+	$allowed = [
+		'/robots.txt',
+	];
+
+	if ( $_SERVER['REQUEST_URI'] && in_array( $_SERVER['REQUEST_URI'], $allowed, true ) ) {
+		add_filter( 'robots_txt', __NAMESPACE__ . '\\create_robots_file' );
+		return;
+	}
+
 	// Check for a basic auth user and password.
 	if ( defined( 'HM_BASIC_AUTH_PW' ) && defined( 'HM_BASIC_AUTH_USER' ) ) {
 		header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
@@ -168,4 +177,16 @@ function require_auth() {
 			exit;
 		}
 	}
+}
+
+/**
+ * Filters the robots.txt output.
+ *
+ * @param string $output The robots.txt output.
+ * @return string The robots.txt output.
+ */
+function create_robots_file( string $output ) {
+	$output = "User-agent: *\n";
+	$output .= "Disallow: /\n";
+	return $output;
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -52,13 +52,13 @@ function is_development_environment() : bool {
 	}
 
 	// Don't require auth for AJAX requests.
-	$exclude_ajax		= ! defined( 'DOING_AJAX' ) || false === DOING_AJAX;
+	$exclude_ajax       = ! defined( 'DOING_AJAX' ) || false === DOING_AJAX;
 	// Don't require auth if we're in wp-cli.
-	$exclude_wp_cli		= ! defined( 'WP_CLI' ) || false === WP_CLI;
+	$exclude_wp_cli     = ! defined( 'WP_CLI' ) || false === WP_CLI;
 	// Don't require auth when running cron jobs.
-	$exclude_cron		= ! defined( 'DOING_CRON' ) || false === DOING_CRON;
+	$exclude_cron       = ! defined( 'DOING_CRON' ) || false === DOING_CRON;
 	// Don't require auth when installing or doing Altis health checks.
-	$exclude_installing	= ! defined( 'WP_INSTALLING' ) || false === WP_INSTALLING;
+	$exclude_installing = ! defined( 'WP_INSTALLING' ) || false === WP_INSTALLING;
 
 	$exclude = $exclude_ajax && $exclude_wp_cli && $exclude_cron && $exclude_installing;
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -156,9 +156,8 @@ function require_auth() {
 
 	/**
 	 * Filters which pages are allowed through basic auth.
-	 *
 	 */
-	$allowed = apply_filters( 'hm-basic-auth.allowed_pages', $allowed );
+	$allowed = apply_filters( 'hm_basic_auth.allowed_pages', $allowed );
 
 	if ( $_SERVER['REQUEST_URI'] && in_array( $_SERVER['REQUEST_URI'], $allowed, true ) ) {
 		add_filter( 'robots_txt', __NAMESPACE__ . '\\create_robots_file' );


### PR DESCRIPTION
Basic auth blocks access to robots.txt which is generated by WP.

This PR allows access to robots.txt when basic auth is enabled.

This PR also sets the robots.txt file to return:
```
User-agent: *
Disallow: /
```

### Steps to confirm:
1. Enable `PHP Basic Auth` on your environment.
2. Confirm `PHP Basic Auth` is active by trying to view a page on the site.
3. Once enabled, try access the `/robots.txt` file and you will see the below:
```
User-agent: *
Disallow: /
```

[Original issue #154](https://github.com/humanmade/altis-security/issues/154)